### PR TITLE
Add sendreq script

### DIFF
--- a/sendreq/go.mod
+++ b/sendreq/go.mod
@@ -1,0 +1,6 @@
+module github.com/okkur-incubator/misc/sendreq
+
+require (
+	github.com/korovkin/limiter v0.0.0-20170610225302-6b837f5fd496
+	github.com/tcnksm/go-httpstat v0.2.0
+)

--- a/sendreq/go.sum
+++ b/sendreq/go.sum
@@ -1,0 +1,4 @@
+github.com/korovkin/limiter v0.0.0-20170610225302-6b837f5fd496 h1:bS17I5YOpfCP6KS7aFOm0/LkZn6J2M/g41+O6LzvtUY=
+github.com/korovkin/limiter v0.0.0-20170610225302-6b837f5fd496/go.mod h1:bttpekv26JrhFNCYlxnxn8a1jw8Q0gi8iHe0RC4JLBg=
+github.com/tcnksm/go-httpstat v0.2.0 h1:rP7T5e5U2HfmOBmZzGgGZjBQ5/GluWUylujl0tJ04I0=
+github.com/tcnksm/go-httpstat v0.2.0/go.mod h1:s3JVJFtQxtBEBC9dwcdTTXS9xFnM3SXAZwPG41aurT8=

--- a/sendreq/main.go
+++ b/sendreq/main.go
@@ -144,9 +144,10 @@ func SendConcurrentRequest(url, host string, timeout time.Duration, ch chan<- ht
 func SendReq(url, host string, timeout time.Duration) httpstat.Result {
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
-		log.Fatal(err)
+		log.Println(err)
+		return httpstat.Result{}
 	}
-	req.Header.Set("Host", host)
+	req.Host = host
 
 	var result httpstat.Result
 	ctx := httpstat.WithHTTPStat(req.Context(), &result)
@@ -158,7 +159,8 @@ func SendReq(url, host string, timeout time.Duration) httpstat.Result {
 	}
 	res, err := client.Do(req)
 	if err != nil {
-		log.Fatal(err)
+		log.Println(err)
+		return httpstat.Result{}
 	}
 	res.Body.Close()
 

--- a/sendreq/main.go
+++ b/sendreq/main.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"time"
+
+	httpstat "github.com/tcnksm/go-httpstat"
+)
+
+const logFormat = "02/Jan/2006:15:04:05 -0700"
+
+func main() {
+	ch := make(chan string)
+
+	// CLI flags
+	endpoint := flag.String("endpoint", "", "HTTP requests endpoint")
+	hostsFile := flag.String("hosts", "", "HTTP requests HOST header file")
+	// parallel := flag.Int("parallel", 1, "Number of parallel requests")
+	// iteration := flag.Int("iteration", -1, "Number of iterations over hosts file")
+	// timeout := flag.Int("timeout", 0, "HTTP requests timeout")
+	flag.Parse()
+
+	// Read hosts file and put them inside a string slice
+	hosts, err := ReadHosts(*hostsFile)
+	if err != nil {
+		log.Fatalf("<%s> ERROR: %s", time.Now().Format(logFormat), err.Error())
+	}
+
+	for _, host := range hosts {
+		go SendRequest(*endpoint, host, ch)
+	}
+
+	for range hosts {
+		fmt.Println(<-ch)
+	}
+}
+
+func ReadHosts(hosts string) ([]string, error) {
+	var lines []string
+	if hosts == "" {
+		return nil, fmt.Errorf("Hosts file is empty. Please provide it with -hosts flag")
+	}
+	file, _ := os.Open(hosts)
+	defer file.Close()
+	scanner := bufio.NewScanner(file)
+	scanner.Split(bufio.ScanLines)
+
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+
+	return lines, nil
+}
+
+func SendRequest(url string, host string, ch chan<- string) {
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	req.Header.Set("Host", host)
+
+	var result httpstat.Result
+	ctx := httpstat.WithHTTPStat(req.Context(), &result)
+	req = req.WithContext(ctx)
+
+	client := http.DefaultClient
+	start := time.Now()
+	res, err := client.Do(req)
+	if err != nil {
+		log.Fatal(err)
+	}
+	secs := time.Since(start).Seconds()
+
+	body, _ := ioutil.ReadAll(res.Body)
+	res.Body.Close()
+
+	ch <- fmt.Sprintf("%.2f elapsed with response length: %d %s", secs, len(body), url)
+}

--- a/sendreq/main.go
+++ b/sendreq/main.go
@@ -46,6 +46,8 @@ func main() {
 		log.Fatalf("[%s] ERROR: %s", logName, err.Error())
 	}
 
+	go logCountEvery15s()
+
 	start := time.Now()
 	if *iteration == -1 {
 		go func() {
@@ -160,4 +162,10 @@ func SendReq(url, host string, timeout time.Duration) httpstat.Result {
 	res.Body.Close()
 
 	return result
+}
+
+func logCountEvery15s() {
+	for range time.Tick(15 * time.Second) {
+		log.Printf("[%s]: Number of requests since the start: %d", logName, count)
+	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Sends requests in parallel and save latency of first request. Also print out the total requests per second achieved, total requests done.

<!--
**Which issue this PR fixes** *(optional - uncomment and add issue)*:
fixes #0
-->

**Special notes for your reviewer**:

**Release note**:
<!--
Optional one line note for this specific change, that can be used in a release-note or changelog.
-->
```release-note

```